### PR TITLE
feat: add unsignedTxTools

### DIFF
--- a/src/core/services/transfer.ts
+++ b/src/core/services/transfer.ts
@@ -435,14 +435,13 @@ export async function buildSeiTransferTx(
   const publicClient = getPublicClient(network);
   const validatedToAddress = services.helpers.validateAddress(toAddress);
   const amountWei = parseEther(amount);
-
   return {
     to: validatedToAddress,
-    value: `0x${amountWei.toString(16)}`,
+    value: amountWei.toString(),
   };
 }
 
-export async function buildTransferERC20(
+export async function  buildTransferERC20(
   tokenAddress: string,
   toAddress: string,
   amount: string,
@@ -454,23 +453,20 @@ export async function buildTransferERC20(
   const publicClient = getPublicClient(network);
 
   const contract = getContract({
+	address: validatedTokenAddress,
     abi: erc20TransferAbi,
     client: publicClient as any,
   });
-
   // Get token decimals and symbol
   const decimals = await contract.read.decimals();
-
   // Parse the amount with the correct number of decimals
   const rawAmount = parseUnits(amount, decimals);
-
   const txRequest = {
     address: tokenAddress,
     abi: erc20TransferAbi,
     functionName: "transfer",
-    args: [validatedToAddress, rawAmount],
+    args: [validatedToAddress, rawAmount.toString()],
   };
-
   return txRequest;
 }
 
@@ -501,7 +497,7 @@ export async function buildApproveERC20(
     address: tokenAddress,
     abi: erc20TransferAbi,
     functionName: "approve",
-    args: [validatedSpenderAddress, rawAmount],
+    args: [validatedSpenderAddress, rawAmount.toString()],
   };
 }
 
@@ -543,7 +539,7 @@ export async function buildTransferERC1155(
     address: tokenAddress,
     abi: erc1155TransferAbi,
     functionName: "safeTransferFrom",
-    args: [validatedFromAddress, validatedToAddress, tokenId, amountBigInt, "0x"],
+    args: [validatedFromAddress, validatedToAddress, tokenId.toString(), amountBigInt.toString(), "0x"],
   };
 }
 


### PR DESCRIPTION
This pull request introduces updates to transaction-building functions and adds new tools for unsigned transaction preparation in the `src/core` directory. The changes focus on improving data handling by ensuring consistent string conversion for transaction arguments and expanding functionality to support various token standards, including ERC20, ERC721, and ERC1155.

### Updates to transaction-building functions:

* [`src/core/services/transfer.ts`](diffhunk://#diff-d3858cc01b223ef78d888942148e4547ce22bf263fda998e434af5e200edad48L438-R440): Updated transaction-building functions (`buildSeiTransferTx`, `buildTransferERC20`, `buildApproveERC20`, `buildTransferERC1155`) to convert numeric arguments (e.g., amounts, token IDs) to strings for consistent handling across the transaction lifecycle. [[1]](diffhunk://#diff-d3858cc01b223ef78d888942148e4547ce22bf263fda998e434af5e200edad48L438-R440) [[2]](diffhunk://#diff-d3858cc01b223ef78d888942148e4547ce22bf263fda998e434af5e200edad48R456-L473) [[3]](diffhunk://#diff-d3858cc01b223ef78d888942148e4547ce22bf263fda998e434af5e200edad48L504-R500) [[4]](diffhunk://#diff-d3858cc01b223ef78d888942148e4547ce22bf263fda998e434af5e200edad48L546-R542)

### Addition of new tools for unsigned transaction preparation:

* `src/core/tools.ts`: Added tools for preparing unsigned transactions for various token standards:
  - [`transfer_erc20`](diffhunk://#diff-ddcea1af5a7f8dd7b80cdeb84ef8f55a48f639609a7b78d3e3229bf3ae03d413R1412-R1562): Supports ERC20 token transfers.
  - [`approve_erc20`](diffhunk://#diff-ddcea1af5a7f8dd7b80cdeb84ef8f55a48f639609a7b78d3e3229bf3ae03d413R1412-R1562): Enables ERC20 token spending approvals.
  - [`transfer_erc721`](diffhunk://#diff-ddcea1af5a7f8dd7b80cdeb84ef8f55a48f639609a7b78d3e3229bf3ae03d413R1412-R1562): Handles NFT transfers (ERC721).
  - [`transfer_erc1155`](diffhunk://#diff-ddcea1af5a7f8dd7b80cdeb84ef8f55a48f639609a7b78d3e3229bf3ae03d413R1412-R1562): Facilitates transfers of ERC1155 tokens, including fungible and non-fungible types.

### Modifications to existing tools:

* [`src/core/tools.ts`](diffhunk://#diff-ddcea1af5a7f8dd7b80cdeb84ef8f55a48f639609a7b78d3e3229bf3ae03d413L1378-R1386): Updated the `transfer_sei` tool to remove the requirement for a sender address, simplifying its usage.